### PR TITLE
Directory wasn't backed up

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -27,6 +27,8 @@ ynh_backup --src_path="$config_path"
 
 ynh_backup --src_path="$data_dir" --is_big
 
+ynh_backup --src_path="/var/lib/$app"
+
 #=================================================
 # SPECIFIC BACKUP
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -42,6 +42,7 @@ ynh_secure_remove --file="$config_path"
 ynh_secure_remove --file="/var/log/$app"
 
 ynh_secure_remove --file="/run/$app"
+ynh_secure_remove --file="/var/lib/$app"
 ynh_secure_remove --file="/usr/bin/prosody"
 ynh_secure_remove --file="/usr/bin/prosodyctl"
 ynh_secure_remove --file="/usr/bin/prosody-migrator"

--- a/scripts/restore
+++ b/scripts/restore
@@ -71,7 +71,7 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
-chown -R $app:$app "/var/lib/$app"
+# chown -R $app:$app "/var/lib/$app"
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -51,8 +51,10 @@ chmod 750 "$config_path/certs"
 ynh_script_progression --message="Restoring the data directory..."
 
 ynh_restore_file --origin_path="$data_dir" --not_mandatory
+ynh_restore_file --origin_path="/var/lib/$app" --not_mandatory
 
 chown -R $app:$app "$data_dir"
+chown -R $app:$app "/var/lib/$app"
 
 #=================================================
 # RESTORE SYSTEMD
@@ -71,7 +73,6 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
-# chown -R $app:$app "/var/lib/$app"
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 


### PR DESCRIPTION
## Problem

- Restoring from a backup on a new instance was failing as the directory was not backed up. It worked on the same instance as the directory was not removed either

## Solution

- Back-up and restore this directory
- Remove the directory when deleting

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
